### PR TITLE
Throttle number of logs written based on channels

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 {deps, [
   {statsderl, "0.4.4",
-    {git, "https://github.com/lpgauth/statsderl.git", {tag, "0.4.4"}}}
+    {git, "https://github.com/lpgauth/statsderl.git", {tag, "0.4.4"}}},
+  {meck, "0.8.3",
+    {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
 ]}.
 
 {erl_opts, [debug_info,

--- a/src/luger_utils.erl
+++ b/src/luger_utils.erl
@@ -5,11 +5,10 @@
          hostname/0,
          channel/1,
          message/1,
-         priority_to_list/1]).
-
-%%-----------------------------------------------------------------
-%% implementation
-%%-----------------------------------------------------------------
+         priority_to_list/1,
+         send_stderr/1,
+         send_syslog/4
+        ]).
 
 trunc(N, S) when is_binary(S) ->
     case S of
@@ -40,3 +39,13 @@ priority_to_list(?WARNING) -> "warning";
 priority_to_list(?NOTICE) -> "notice";
 priority_to_list(?INFO) -> "info";
 priority_to_list(?DEBUG) -> "debug".
+
+
+%% Exist so we can trap the call via meck without disrupting other
+%% parts of the system. Need to come up with something better.
+
+send_stderr(Line) ->
+    io:put_chars(standard_error, Line).
+
+send_syslog(Socket, Host, Port, Line) ->
+    inet_udp:send(Socket, Host, Port, Line).

--- a/test/luger_test.erl
+++ b/test/luger_test.erl
@@ -1,9 +1,67 @@
 -module(luger_test).
 
+-include("src/luger.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-no_start_test() ->
-    {error, _} = luger:alert("chan.alert", "format: ~s", ["blah"]).
+-define(NOW, {{0, 0, 0}, {0, 0, 0}}).
+-define(FACILITY, 23).
+
+-define(assert_statsd(Logger, ExpKey, ExpCount),
+        fun() ->
+                ExpKey1 = iolist_to_binary(ExpKey),
+
+                {Key, Count} = case logger_get(Logger, statsd) of L when L /= undefined -> L end,
+                Key1 = iolist_to_binary(Key),
+
+                ?assertMatch({ExpKey1, ExpCount}, {Key1, Count})
+        end()).
+
+-define(assert_log_line(Logger, Source, ExpPriority, ExpChannel, ExpMessage),
+        fun() ->
+                Line = case logger_get(Logger, Source) of L when L /= undefined -> L end,
+                ExpLine = format_log(Source, ExpPriority, ExpChannel, ExpMessage),
+                ?assertEqual(iolist_to_binary(ExpLine), iolist_to_binary(Line))
+        end()).
+
+-define(assert_log_count(Logger, Source, MinCount, MaxCount),
+        fun() ->
+                Count = logger_count(Logger, Source, 0),
+                ?assert(Count >= MinCount),
+                ?assert(Count =< MaxCount)
+        end()).
+
+
+-define(assert_log_monitor(Logger, Source),
+        fun() ->
+                timer:sleep(100), % wait for asynchronous message to show up
+                case logger_get(Logger, Source) of L when L /= undefined -> L end
+        end()).
+
+-define(assert_log_empty(Logger),
+        begin
+            ?assertMatch(undefined, logger_get(Logger, syslog)),
+            ?assertMatch(undefined, logger_get(Logger, stderr)),
+            ?assertMatch(undefined, logger_get(Logger, statsd))
+        end).
+
+% I f'n hate eunit...
+-define(T(Name, Body),
+        fun(Logger) ->
+                {Name, ?_test(begin _ = Logger, Body end)}
+        end).
+
+no_start_test_() ->
+    {foreach,
+     fun () -> setup() end,
+     fun (Logger) -> terminate(Logger) end,
+     [
+      ?T("luger not started",
+         begin
+             {error, _} = luger:alert("start.alert", "format: ~s", ["blah"]),
+             ?assert_log_empty(Logger)
+         end)
+     ]}.
+
 
 
 stderr_test_() ->
@@ -12,25 +70,42 @@ stderr_test_() ->
              application:load(luger),
              application:set_env(luger, app_name, "luger_test"),
              application:set_env(luger, type, stderr),
-             application:start(luger)
+             application:set_env(luger, statsd, false),
+             application:start(luger),
+             setup()
      end,
-     fun(_) ->
+     fun(Logger) ->
+             terminate(Logger),
              application:stop(luger)
      end,
      [
-      {"basic stderr logging",
-       fun () ->
-               ok = luger:alert("chan.alert", "format: ~s", ["blah"]),
-               ok = luger:error("chan.error", "format: ~B", [10]),
-               ok = luger:warning("chan.warn", "format: ~p", [blah]),
-               ok = luger:info("chan.info", "msg"),
-               ok = luger:debug("chan.debug", "msg")
-       end},
-      {"trunc",
-       fun () ->
-               ok = luger:alert(string:chars($a, 32, "b"), "msg"),
-               ok = luger:alert("trunc", string:chars($a, 2048, "b"))
-       end}
+      ?T("stderr - basics",
+         begin
+             ok = luger:alert("stderr.alert", "format: ~s", ["blah"]),
+             ?assert_log_line(Logger, stderr, alert, "stderr.alert", "format: blah"),
+
+             ok = luger:error("stderr.error", "format: ~B", [10]),
+             ?assert_log_line(Logger, stderr, error, "stderr.error", "format: 10"),
+
+             ok = luger:warning("stderr.warn", "format: ~p", [blah]),
+             ?assert_log_line(Logger, stderr, warning, "stderr.warn", "format: blah"),
+
+             % dropped due to log threshold
+             ok = luger:info("stderr.info", "msg"),
+             ok = luger:debug("stderr.debug", "msg"),
+             ?assert_log_empty(Logger)
+         end),
+
+      ?T("stderr - truncation",
+         begin
+             ok = luger:alert(string:chars($a, 32, "b"), "msg"),
+             ?assert_log_line(Logger, stderr, alert, string:chars($a, 32), "msg"),
+
+             ok = luger:alert("stderr.trunc", string:chars($a, 2048, "b")),
+             ?assert_log_line(Logger, stderr, alert, "stderr.trunc", string:chars($a, 2048)),
+
+             ?assert_log_empty(Logger)
+         end)
      ]}.
 
 
@@ -41,20 +116,33 @@ stderr_prio_test_() ->
              application:set_env(luger, app_name, "luger_test"),
              application:set_env(luger, type, stderr),
              application:set_env(luger, stderr_min_priority, debug),
-             application:start(luger)
+             application:start(luger),
+             setup()
      end,
-     fun(_) ->
+     fun(Logger) ->
+             terminate(Logger),
              application:stop(luger)
      end,
      [
-      {"priority stderr logging",
-       fun () ->
-               ok = luger:alert("chan.alert", "format: ~s", ["blah"]),
-               ok = luger:error("chan.error", "format: ~B", [10]),
-               ok = luger:warning("chan.warn", "format: ~p", [blah]),
-               ok = luger:info("chan.info", "msg"),
-               ok = luger:debug("chan.debug", "msg")
-       end}
+      ?T("stderr - min priority",
+         begin
+             ok = luger:alert("stderr.prio.alert", "format: ~s", ["blah"]),
+             ?assert_log_line(Logger, stderr, alert, "stderr.prio.alert", "format: blah"),
+
+             ok = luger:error("stderr.prio.error", "format: ~B", [10]),
+             ?assert_log_line(Logger, stderr, error, "stderr.prio.error", "format: 10"),
+
+             ok = luger:warning("stderr.prio.warn", "format: ~p", [blah]),
+             ?assert_log_line(Logger, stderr, warning, "stderr.prio.warn", "format: blah"),
+
+             ok = luger:info("stderr.prio.info", "msg"),
+             ?assert_log_line(Logger, stderr, info, "stderr.prio.info", "msg"),
+
+             ok = luger:debug("stderr.prio.debug", "msg"),
+             ?assert_log_line(Logger, stderr, debug, "stderr.prio.debug", "msg"),
+
+             ?assert_log_empty(Logger)
+         end)
      ]}.
 
 syslog_test_() ->
@@ -65,26 +153,45 @@ syslog_test_() ->
              application:set_env(luger, type, syslog_udp),
              application:set_env(luger, syslog_udp_host, {127, 0, 0, 1}),
              application:set_env(luger, syslog_udp_port, 514),
-             application:set_env(luger, syslog_udp_facility, 23),
-             application:start(luger)
+             application:set_env(luger, syslog_udp_facility, ?FACILITY),
+             application:start(luger),
+             setup()
      end,
-     fun(_) ->
+     fun(Logger) ->
+             terminate(Logger),
              application:stop(luger)
      end,
      [
-      {"basic syslog logging",
-       fun () ->
-               ok = luger:alert("chan.alert", "format: ~s", ["blah"]),
-               ok = luger:error("chan.error", "format: ~B", [10]),
-               ok = luger:warning("chan.warn", "format: ~p", [blah]),
-               ok = luger:info("chan.info", "msg"),
-               ok = luger:debug("chan.debug", "msg")
-       end},
-      {"trunc",
-       fun () ->
-               ok = luger:alert("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbb", "msg"),
-               ok = luger:alert(<<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbb">>, "msg")
-       end}
+      ?T("syslog - basics",
+         begin
+             ok = luger:alert("syslog.alert", "format: ~s", ["blah"]),
+             ?assert_log_line(Logger, syslog, alert, "syslog.alert", "format: blah"),
+
+             ok = luger:error("syslog.error", "format: ~B", [10]),
+             ?assert_log_line(Logger, syslog, error, "syslog.error", "format: 10"),
+
+             ok = luger:warning("syslog.warn", "format: ~p", [blah]),
+             ?assert_log_line(Logger, syslog, warning, "syslog.warn", "format: blah"),
+
+             ok = luger:info("syslog.info", "msg"),
+             ?assert_log_line(Logger, syslog, info, "syslog.info", "msg"),
+
+             ok = luger:debug("syslog.debug", "msg"),
+             ?assert_log_line(Logger, syslog, debug, "syslog.debug", "msg"),
+
+             ?assert_log_empty(Logger)
+         end),
+
+      ?T("syslog - truncation",
+         begin
+             ok = luger:alert(string:chars($a, 32, "b"), "msg"),
+             ?assert_log_line(Logger, syslog, alert, string:chars($a, 32), "msg"),
+
+             ok = luger:alert("trunc", string:chars($a, 2048, "b")),
+             ?assert_log_line(Logger, syslog, alert, "trunc", string:chars($a, 2048)),
+
+             ?assert_log_empty(Logger)
+         end)
      ]}.
 
 error_logger_test_() ->
@@ -93,24 +200,31 @@ error_logger_test_() ->
              application:load(luger),
              application:set_env(luger, app_name, "luger_test"),
              application:set_env(luger, type, stderr),
-             application:start(luger)
+             application:start(luger),
+             setup()
      end,
-     fun(_) ->
+     fun(Logger) ->
+             terminate(Logger),
              application:stop(luger)
      end,
      [
-      {"basic error logger",
-       fun () ->
-               error_logger:error_msg("error_msg: ~p ~p", [{blah, blah}, bleh]),
-               error_logger:error_report("error_report")
-       end}
-     ]}.
 
+      %% Creates an unknown number of line and I can't be bothered to
+      %% figure out what is what from where so we just check that we
+      %% got something and walk away happy.
+      ?T("error monitor - basics",
+         begin
+             error_logger:error_msg("error_msg: ~p ~p", [{blah, blah}, bleh]),
+             ?assert_log_monitor(Logger, stderr),
+
+             error_logger:error_report("error_report"),
+             ?assert_log_monitor(Logger, stderr)
+         end)
+     ]}.
 
 statsd_test_() ->
     {foreach,
      fun() ->
-             %% Should meck this up.
              application:load(statsderl),
              application:set_env(statsderl, hostname, {127, 0, 0, 1}),
              application:set_env(statsderl, port, 8125),
@@ -119,19 +233,144 @@ statsd_test_() ->
              application:load(luger),
              application:set_env(luger, app_name, "luger_test"),
              application:set_env(luger, type, stderr),
+             application:set_env(luger, stderr_min_priority, warning),
              application:set_env(luger, statsd, true),
-             application:start(luger)
+             application:start(luger),
+
+             setup()
      end,
-     fun(_) ->
+     fun(Logger) ->
+             terminate(Logger),
              application:stop(luger)
      end,
      [
-      {"statsd metrics",
-       fun () ->
-               ok = luger:alert("chan.alert", "format: ~s", ["blah"]),
-               ok = luger:error("chan.error", "format: ~B", [10]),
-               ok = luger:warning("chan.warn", "format: ~p", [blah]),
-               ok = luger:info("chan.info", "msg"),
-               ok = luger:debug("chan.debug", "msg")
-       end}
+      ?T("statsd metrics",
+         begin
+             ok = luger:alert("statsd", "msg"),
+             ?assert_log_line(Logger, stderr, alert, "statsd", "msg"),
+             ?assert_statsd(Logger, "luger.alert.statsd", 1),
+
+             ok = luger:error("statsd", "msg"),
+             ?assert_log_line(Logger, stderr, error, "statsd", "msg"),
+             ?assert_statsd(Logger, "luger.error.statsd", 1),
+
+             ok = luger:warning("statsd", "msg"),
+             ?assert_log_line(Logger, stderr, warning, "statsd", "msg"),
+             ?assert_statsd(Logger, "luger.warning.statsd", 1),
+
+             ok = luger:info("statsd", "msg"),
+             ?assert_statsd(Logger, "luger.info.statsd", 1),
+
+             ok = luger:debug("statsd", "msg"),
+             ?assert_statsd(Logger, "luger.debug.statsd", 1),
+
+             ?assert_log_empty(Logger)
+         end)
      ]}.
+
+%% These tests might be a bit flaky due to their reliance on
+%% time. They were design to reduce this flakyness though at the cost
+%% of potential false-positives. Should iron out over many executions.
+throttling_test_() ->
+    {foreach,
+     fun() ->
+             application:load(luger),
+             application:set_env(luger, app_name, "luger_test"),
+             application:set_env(luger, type, stderr),
+             application:set_env(luger, statsd, true),
+             application:start(luger),
+             setup()
+     end,
+     fun(Logger) ->
+             terminate(Logger),
+             application:stop(luger)
+     end,
+     [
+      ?T("throttling",
+         begin
+             [luger:alert("throttling.main", "msg") || _ <- lists:seq(0, 100)],
+             ?assert_log_count(Logger, stderr, 5, 10),
+             ?assert_log_count(Logger, statsd, 5, 10),
+             ?assert_log_empty(Logger),
+
+             luger:alert("throttling.other", "msg"),
+             ?assert_log_count(Logger, stderr, 1, 1),
+             ?assert_log_count(Logger, statsd, 1, 1),
+             ?assert_log_empty(Logger),
+
+             timer:sleep(1000),
+             luger:alert("throttling.main", "msg"),
+             ?assert_log_count(Logger, stderr, 1, 1),
+             ?assert_log_count(Logger, statsd, 1, 1),
+             ?assert_log_empty(Logger),
+
+             timer:sleep(1000),
+             [luger:alert("throttling.main", "msg") || _ <- lists:seq(0, 100)],
+             ?assert_log_count(Logger, stderr, 5, 10),
+             ?assert_log_count(Logger, statsd, 5, 10),
+             ?assert_log_empty(Logger)
+         end)
+     ]}.
+
+
+format_log(stderr, Priority, Channel, Message) ->
+    io_lib:format(
+      "<~p> 0000-00-00T00:00:00 ~s luger_test ~p ~s  ~s~n",
+      [Priority, luger_utils:hostname(), self(), Channel, Message]);
+format_log(syslog, Priority, Channel, Message) ->
+    PriorityNum = ?FACILITY * 8 +  case Priority of
+                                       alert -> ?ALERT;
+                                       error -> ?ERROR;
+                                       warning -> ?WARNING;
+                                       info -> ?INFO;
+                                       debug -> ?DEBUG
+                                   end,
+    io_lib:format(
+      "<~p>1 0000-00-00T00:00:00 ~s luger_test ~p ~s  ~s",
+      [PriorityNum, luger_utils:hostname(), self(), Channel, Message]).
+
+logger_loop() ->
+    receive
+        close -> ok;
+        {get, Source, Pid} ->
+            receive
+                {log, Source, Data} -> Pid ! {log, Source, Data}
+            after
+                0 -> Pid ! {log, Source, undefined}
+            end,
+            logger_loop()
+    end.
+
+logger_get(Logger, Source) ->
+    Logger ! {get, Source, self()},
+    receive {log, Source, Data} -> Data end.
+
+logger_count(Logger, Source, Acc) ->
+    case logger_get(Logger, Source) of
+        undefined -> Acc;
+        _ -> logger_count(Logger, Source, Acc + 1)
+    end.
+
+setup() ->
+    Logger = spawn(fun() -> logger_loop() end),
+
+    meck:new(luger_utils, [passthrough]),
+    meck:expect(luger_utils, send_stderr,
+                fun (Line) -> Logger ! {log, stderr, Line}, ok end),
+    meck:expect(luger_utils, send_syslog,
+                fun (_, _, _, Line) -> Logger ! {log, syslog, Line}, ok end),
+
+    meck:new(statsderl),
+    meck:expect(statsderl, increment,
+                fun (Key, Inc, _) -> Logger ! {log, statsd, {Key, Inc}} end),
+
+    meck:new(calendar, [unstick]),
+    meck:expect(calendar, local_time, fun () -> ?NOW end),
+
+    Logger.
+
+terminate(Logger) ->
+    meck:unload(calendar),
+    meck:unload(statsderl),
+    meck:unload(luger_utils),
+    Logger ! close.


### PR DESCRIPTION
Turns out that even if we send directly to a UDP socket, it's still possible to flood the kernel's network stack and cause luger to deadlock on the `prim_inet` ports when trying to send a message. This might be fixable by sending to a unix socket which would require R19. In the meanwhile, we can mitigate issues by only allowing luger to send 5 log messages per second.

I also took the opportunity to rewrite the tests to remove their reliance on external services. This avoids having to use tcpdump and whatnot to make sure that luger works properly.
