### PR TITLE
Correctly handle all possible inputs

### DIFF
--- a/src/luger_utils.erl
+++ b/src/luger_utils.erl
@@ -6,7 +6,7 @@
          channel/1,
          message/1,
          priority_to_list/1,
-         send_stderr/1,
+         send_stderr/1, send_stderr/2,
          send_syslog/4
         ]).
 
@@ -44,8 +44,12 @@ priority_to_list(?DEBUG) -> "debug".
 %% Exist so we can trap the call via meck without disrupting other
 %% parts of the system. Need to come up with something better.
 
+send_stderr(IoDevice, Line) ->
+    io:format(IoDevice, "~s", [Line]).
+
 send_stderr(Line) ->
-    io:put_chars(standard_error, Line).
+    send_stderr(standard_error, Line).
+
 
 send_syslog(Socket, Host, Port, Line) ->
     inet_udp:send(Socket, Host, Port, Line).


### PR DESCRIPTION
Fix the issue where `io:put_chars` can throw if you feed it characters `> 127` due to a call to `unicode:characters_to_binary(Bin, latin1, unicode)`. Instead we move to a simpler `io:format` call which will deal with encoding issues for us.
