### PR TITLE
Add null logger

### DIFF
--- a/src/luger.erl
+++ b/src/luger.erl
@@ -103,7 +103,7 @@ debug(Channel, Format, Args) ->
           app                             :: string(),
           host                            :: string(),
           statsd                          :: boolean(),
-          type                            :: stderr | syslog_udp,
+          type                            :: null | stderr | syslog_udp,
           stderr_min_priority = ?WARNING  :: integer(),
           syslog_udp_socket = undefined   :: undefined | socket(),
           syslog_udp_host   = undefined   :: undefined | string(),
@@ -131,6 +131,8 @@ terminate(_Reason, _State) ->
 %% implementation
 %%-----------------------------------------------------------------
 
+init_sink(State = #state{}, #null_config{}) ->
+    State#state{type = null};
 init_sink(State = #state{}, #stderr_config{ min_priority = MinPriority }) ->
     State#state{type = stderr,
                 stderr_min_priority = MinPriority};
@@ -205,6 +207,8 @@ stderr_priority(?NOTICE) -> <<"<notice>">>;
 stderr_priority(?INFO) -> <<"<info>">>;
 stderr_priority(?DEBUG) -> <<"<debug>">>.
 
+log_to(_Priority, null, _Data, _State) ->
+    ok;
 log_to(Priority, stderr, Data, #state{stderr_min_priority = MinPriority}) ->
     case Priority of
         _ when Priority =< MinPriority ->

--- a/src/luger.hrl
+++ b/src/luger.hrl
@@ -16,3 +16,5 @@
                              facility :: integer() }).
 
 -record(stderr_config, { min_priority :: integer() }).
+
+-record(null_config, {}).

--- a/src/luger_sup.erl
+++ b/src/luger_sup.erl
@@ -59,6 +59,7 @@ init([]) ->
     Args = args(),
     SinkArgs = case application:get_env(type) of
                undefined -> stderr_args();
+               {ok, null} -> #null_config {};
                {ok, stderr} -> stderr_args();
                {ok, syslog_udp} -> syslog_udp_args()
            end,


### PR DESCRIPTION
This commit adds a logger that discards its input.  This is a helpful
handler for unit tests, when we want to avoid extraneous output and
filling up a log file.