### PR TITLE
Add throttle_threshold

### DIFF
--- a/src/luger.erl
+++ b/src/luger.erl
@@ -161,7 +161,7 @@ log(Priority, Channel, Message, _) ->
 
     #state{throttle_threshold = Threshold} = State,
 
-    Now = erlang:monotonic_time(seconds),
+    Now = luger_utils:get_time(),
     Throttle = throttle_channel(Channel, Now, ets:lookup(?TABLE, Channel), Threshold),
 
     log(State, Priority, Channel, Message, Throttle).

--- a/src/luger_sup.erl
+++ b/src/luger_sup.erl
@@ -69,5 +69,10 @@ init([]) ->
                      _ -> false
                  end,
 
-    Children = [{luger, {luger, start_link, [Args, SinkArgs, SingleLine]}, permanent, 1000, worker, [luger]}],
+    ThrottleThreshold = case application:get_env(throttle_threshold) of
+        {ok, Val} -> Val;
+        _ -> 5
+    end,
+
+    Children = [{luger, {luger, start_link, [Args, SinkArgs, SingleLine, ThrottleThreshold]}, permanent, 1000, worker, [luger]}],
     {ok, {{one_for_one, 0, 1}, Children}}.

--- a/src/luger_utils.erl
+++ b/src/luger_utils.erl
@@ -7,7 +7,8 @@
          message/2,
          priority_to_list/1,
          send_stderr/1, send_stderr/2,
-         send_syslog/4
+         send_syslog/4,
+         get_time/0
         ]).
 
 trunc(N, S) when is_binary(S) ->
@@ -58,3 +59,9 @@ send_stderr(Line) ->
 
 send_syslog(Socket, Host, Port, Line) ->
     inet_udp:send(Socket, Host, Port, Line).
+
+
+%% Used in order to mock time in test suite
+
+get_time() ->
+    erlang:monotonic_time(seconds).

--- a/test/luger_test_server.erl
+++ b/test/luger_test_server.erl
@@ -1,0 +1,77 @@
+-module(luger_test_server).
+
+-behaviour(gen_server).
+
+-export([start_link/0,
+         log/2,
+         get_time/0,
+         inc_time/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+log(Source, Msg) ->
+    gen_server:call(?SERVER, {log, Source, Msg}).
+
+get_time() ->
+    gen_server:call(?SERVER, get_time).
+
+inc_time(Ms) ->
+    gen_server:call(?SERVER, {inc_time, Ms}).
+
+init([]) ->
+    {ok, {erlang:monotonic_time(millisecond), #{}}}.
+
+handle_call(get_time, _From, State = {Time, _}) ->
+    {reply, Time, State};
+
+handle_call({inc_time, Ms}, _From, {Time, Map}) ->
+    {reply, ok, {Time + Ms, Map}};
+
+handle_call({log, Source, Msg}, _From, {Time, Map}) ->
+    Map2 = case Map of
+        #{Source := {Msgs, Read}} ->
+            Map#{Source => {[Msg | Msgs], Read}};
+        _ ->
+            Map#{Source => {[Msg], []}}
+    end,
+    {reply, ok, {Time, Map2}};
+
+handle_call({get, Source}, _From, State = {Time, Map}) ->
+    case Map of
+        #{Source := {[], _}} ->
+            {reply, undefined, State};
+        #{Source := {Msgs, Read}} ->
+            Out = lists:reverse(Msgs),
+            % Keep already-read messages around to disambiguate the
+            % 'already-read' case from the 'haven't-received-yet' case
+            Map2 = Map#{Source => {[], Read ++ Out}},
+            {reply, Out, {Time, Map2}};
+        _ ->
+            {reply, undefined, State}
+    end;
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(close, State) ->
+    {stop, normal, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
Rather than using `?THROTTLE_THRESHOLD`, as specified in luger.erl, this PR adds a `throttle_threshold` field to the `#state` record, and exposes it as as configuration option for end-users.

It also logs a message when un-throttled that reports how many messages were dropped.