### PR TITLE
Replace 'undefined' max_msg_len with 'infinity'

### DIFF
--- a/src/luger.erl
+++ b/src/luger.erl
@@ -110,7 +110,7 @@ debug(Channel, Format, Args) ->
           syslog_udp_host   = undefined   :: undefined | string(),
           syslog_udp_port   = undefined   :: undefined | integer(),
           syslog_udp_facility = undefined :: undefined | integer(),
-          max_msg_len                     :: undefined | integer()
+          max_msg_len                     :: infinity | integer()
          }).
 
 init([#config{app = AppName, host = HostName, max_msg_len = MaxLen}, SinkConfig, SingleLine, ThrottleThreshold]) ->

--- a/src/luger_sup.erl
+++ b/src/luger_sup.erl
@@ -21,7 +21,11 @@ start_link() ->
 args() ->
     {ok, AppName} = application:get_env(luger, app_name),
     HostName = luger_utils:hostname(),
-    MaxLen = application:get_env(luger, max_msg_len, 2048),
+    MaxLen = case application:get_env(luger, max_msg_len) of
+        undefined -> 2048;
+        {ok, N} when is_integer(N) -> N;
+        {ok, infinity} -> infinity
+    end,
     #config{app = luger_utils:appname(AppName),
             host = HostName,
             max_msg_len = MaxLen }.

--- a/src/luger_utils.erl
+++ b/src/luger_utils.erl
@@ -34,7 +34,7 @@ single_line(Msg, false) ->
 single_line(Msg, true) ->
     lists:join(" ", binary:split(iolist_to_binary(Msg), [<<"\n">>, <<" ">>], [global, trim_all])).
 
-message(Msg, SingleLine, undefined) ->
+message(Msg, SingleLine, infinity) ->
     single_line(Msg, SingleLine);
 message(Msg, SingleLine, MaxLen) ->
     trunc(MaxLen, single_line(Msg, SingleLine)).


### PR DESCRIPTION
Previously, `application:get_env(luger, max_msg_len)` would return `undefined` for an unset value, causing the default to be 2048, or `{ok, undefined}` for no maximum (i.e no truncation should take place). I've changed it so that `infinity` is used instead, making it clearer when there is and isn't a maximum message length.